### PR TITLE
Removes support for passing in a custom IDateTimeProvider instance through the public API

### DIFF
--- a/demo/EXBP.Dipren.Demo.SQLite/EntryPoint.cs
+++ b/demo/EXBP.Dipren.Demo.SQLite/EntryPoint.cs
@@ -100,7 +100,7 @@ namespace EXBP.Dipren.Demo.SQLite
         {
             TimeSpan pollinInterval = TimeSpan.FromMilliseconds(POLLING_INTERVAL);
             Configuration configuration = new Configuration(TimeSpan.Zero, pollinInterval);
-            Engine engine = new Engine(store, ConsoleEventLogger.Information, UtcDateTimeProvider.Default);
+            Engine engine = new Engine(store, ConsoleEventLogger.Information);
 
             await engine.RunAsync(job, false);
         }

--- a/source/EXBP.Dipren/Engine.cs
+++ b/source/EXBP.Dipren/Engine.cs
@@ -29,18 +29,36 @@ namespace EXBP.Dipren
         /// <param name="store">
         ///   The <see cref="IEngineDataStore"/> to use.
         /// </param>
-        /// <param name="handler">
-        ///   The <see cref="IEventHandler"/> object to use to emit event notifications; or <see langword="null"/> to
-        ///   discard event notifications.
-        /// </param>
         /// <param name="clock">
         ///   A <see cref="IDateTimeProvider"/> that can be used to generate timestamp values; or
         ///   <see langword="null"/> to use a <see cref="UtcDateTimeProvider"/> instance.
         /// </param>
+        /// <param name="handler">
+        ///   The <see cref="IEventHandler"/> object to use to emit event notifications; or <see langword="null"/> to
+        ///   discard event notifications.
+        /// </param>
         /// <param name="configuration">
         ///   The configuration settings to use; or <see langword="null"/> to use the default configuration settings.
         /// </param>
-        public Engine(IEngineDataStore store, IEventHandler handler = null, IDateTimeProvider clock = null, Configuration configuration = null) : base(NodeType.Engine, store, clock, handler)
+        internal Engine(IEngineDataStore store, IDateTimeProvider clock, IEventHandler handler = null, Configuration configuration = null) : base(NodeType.Engine, store, clock, handler)
+        {
+            this._configuration = (configuration ?? new Configuration());
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="Engine"/> class.
+        /// </summary>
+        /// <param name="store">
+        ///   The <see cref="IEngineDataStore"/> to use.
+        /// </param>
+        /// <param name="handler">
+        ///   The <see cref="IEventHandler"/> object to use to emit event notifications; or <see langword="null"/> to
+        ///   discard event notifications.
+        /// </param>
+        /// <param name="configuration">
+        ///   The configuration settings to use; or <see langword="null"/> to use the default configuration settings.
+        /// </param>
+        public Engine(IEngineDataStore store, IEventHandler handler = null, Configuration configuration = null) : base(NodeType.Engine, store, null, handler)
         {
             this._configuration = (configuration ?? new Configuration());
         }

--- a/source/EXBP.Dipren/Scheduler.cs
+++ b/source/EXBP.Dipren/Scheduler.cs
@@ -20,26 +20,26 @@ namespace EXBP.Dipren
         /// <param name="store">
         ///   The <see cref="IEngineDataStore"/> to use.
         /// </param>
-        /// <param name="handler">
-        ///   The <see cref="IEventHandler"/> object to use to emit event notifications.
-        /// </param>
         /// <param name="clock">
         ///   The <see cref="IDateTimeProvider"/> to use to generate timestamps.
         /// </param>
-        internal Scheduler(IEngineDataStore store, IEventHandler handler, IDateTimeProvider clock) : base(NodeType.Scheduler, store, clock, handler)
+        /// <param name="handler">
+        ///   The <see cref="IEventHandler"/> object to use to emit event notifications.
+        /// </param>
+        internal Scheduler(IEngineDataStore store, IDateTimeProvider clock, IEventHandler handler) : base(NodeType.Scheduler, store, clock, handler)
         {
         }
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="Engine"/> class.
         /// </summary>
-        /// <param name="logger">
-        ///   The <see cref="IEventHandler"/> object to use to emit event notifications.
-        /// </param>
         /// <param name="store">
         ///   The <see cref="IEngineDataStore"/> to use.
         /// </param>
-        public Scheduler(IEngineDataStore store, IEventHandler logger = null) : this(store, logger, UtcDateTimeProvider.Default)
+        /// <param name="handler">
+        ///   The <see cref="IEventHandler"/> object to use to emit event notifications.
+        /// </param>
+        public Scheduler(IEngineDataStore store, IEventHandler handler = null) : this(store, UtcDateTimeProvider.Default, handler)
         {
         }
 

--- a/source/EXBP.Dipren/UtcDateTimeProvider.cs
+++ b/source/EXBP.Dipren/UtcDateTimeProvider.cs
@@ -4,7 +4,7 @@ namespace EXBP.Dipren
     /// <summary>
     ///   Implements an <see cref="IDateTimeProvider"/> that returns the current date and time, expressed as UTC time.
     /// </summary>
-    public class UtcDateTimeProvider : IDateTimeProvider
+    internal class UtcDateTimeProvider : IDateTimeProvider
     {
         /// <summary>
         ///   Gets a default instance of the <see cref="UtcDateTimeProvider"/> class.


### PR DESCRIPTION
Custom `IDateTimeProvider` implementations are supported only for internal APIs.