### PR TITLE
Removes the responsibility of calculating the number processed and remaining keys from IEngineDataStore implementations

### DIFF
--- a/source/EXBP.Dipren.Tests/Data/EngineDataStoreTests.cs
+++ b/source/EXBP.Dipren.Tests/Data/EngineDataStoreTests.cs
@@ -835,7 +835,7 @@ namespace EXBP.Dipren.Tests.Data
             Guid id = Guid.NewGuid();
             DateTime timestamp = DateTime.UtcNow;
 
-            Assert.ThrowsAsync<ArgumentNullException>(() => store.ReportProgressAsync(id, null, timestamp, "d", 4, false, 4231.1, CancellationToken.None));
+            Assert.ThrowsAsync<ArgumentNullException>(() => store.ReportProgressAsync(id, null, timestamp, "d", 4, 2, false, 4231.1, CancellationToken.None));
         }
 
         [Test]
@@ -846,7 +846,7 @@ namespace EXBP.Dipren.Tests.Data
             Guid id = Guid.NewGuid();
             DateTime timestamp = DateTime.UtcNow;
 
-            Assert.ThrowsAsync<ArgumentNullException>(() => store.ReportProgressAsync(id, "owner", timestamp, null, 4, false, 4231.1, CancellationToken.None));
+            Assert.ThrowsAsync<ArgumentNullException>(() => store.ReportProgressAsync(id, "owner", timestamp, null, 4, 2, false, 4231.1, CancellationToken.None));
         }
 
         [Test]
@@ -857,7 +857,7 @@ namespace EXBP.Dipren.Tests.Data
             Guid id = Guid.NewGuid();
             DateTime timestamp = DateTime.UtcNow;
 
-            Assert.ThrowsAsync<UnknownIdentifierException>(() => store.ReportProgressAsync(id, "owner", timestamp, "d", 4, false, 4231.1, CancellationToken.None));
+            Assert.ThrowsAsync<UnknownIdentifierException>(() => store.ReportProgressAsync(id, "owner", timestamp, "d", 4, 2, false, 4231.1, CancellationToken.None));
         }
 
         [Test]
@@ -877,7 +877,7 @@ namespace EXBP.Dipren.Tests.Data
 
             DateTime progressUpdated = new DateTime(2022, 9, 12, 16, 26, 11, DateTimeKind.Utc);
 
-            Assert.ThrowsAsync<LockException>(() => store.ReportProgressAsync(id, "owner", progressUpdated, "g", 3, false, 4231.1, CancellationToken.None));
+            Assert.ThrowsAsync<LockException>(() => store.ReportProgressAsync(id, "owner", progressUpdated, "g", 3, 1, false, 4231.1, CancellationToken.None));
         }
 
         [Test]
@@ -897,7 +897,7 @@ namespace EXBP.Dipren.Tests.Data
 
             DateTime progressUpdated = new DateTime(2022, 9, 12, 16, 26, 11, DateTimeKind.Utc);
 
-            await store.ReportProgressAsync(id, "owner", progressUpdated, "g", 3L, true, 4231.1, CancellationToken.None);
+            await store.ReportProgressAsync(id, "owner", progressUpdated, "g", 5L, 19L, true, 4231.1, CancellationToken.None);
 
             Partition persisted = await store.RetrievePartitionAsync(id, CancellationToken.None);
 
@@ -909,8 +909,8 @@ namespace EXBP.Dipren.Tests.Data
             Assert.That(persisted.Last, Is.EqualTo(partition.Last));
             Assert.That(persisted.IsInclusive, Is.EqualTo(partition.IsInclusive));
             Assert.That(persisted.Position, Is.EqualTo("g"));
-            Assert.That(persisted.Processed, Is.EqualTo(partition.Processed + 3L));
-            Assert.That(persisted.Remaining, Is.EqualTo(partition.Remaining - 3L));
+            Assert.That(persisted.Processed, Is.EqualTo(5L));
+            Assert.That(persisted.Remaining, Is.EqualTo(19L));
             Assert.That(persisted.IsCompleted, Is.True);
             Assert.That(persisted.Throughput, Is.EqualTo(4231.1));
             Assert.That(persisted.IsSplitRequested, Is.EqualTo(partition.IsSplitRequested));
@@ -933,7 +933,7 @@ namespace EXBP.Dipren.Tests.Data
 
             DateTime progressUpdated = new DateTime(2022, 9, 12, 16, 26, 11, DateTimeKind.Utc);
 
-            Partition returned = await store.ReportProgressAsync(id, "owner", progressUpdated, "g", 3L, true, 4231.1, CancellationToken.None);
+            Partition returned = await store.ReportProgressAsync(id, "owner", progressUpdated, "g", 5L, 19L, true, 4231.1, CancellationToken.None);
 
             Assert.That(returned.JobId, Is.EqualTo(partition.JobId));
             Assert.That(returned.Created, Is.EqualTo(partition.Created));
@@ -943,8 +943,8 @@ namespace EXBP.Dipren.Tests.Data
             Assert.That(returned.Last, Is.EqualTo(partition.Last));
             Assert.That(returned.IsInclusive, Is.EqualTo(partition.IsInclusive));
             Assert.That(returned.Position, Is.EqualTo("g"));
-            Assert.That(returned.Processed, Is.EqualTo(partition.Processed + 3L));
-            Assert.That(returned.Remaining, Is.EqualTo(partition.Remaining - 3L));
+            Assert.That(returned.Processed, Is.EqualTo(5L));
+            Assert.That(returned.Remaining, Is.EqualTo(19L));
             Assert.That(returned.IsCompleted, Is.True);
             Assert.That(returned.Throughput, Is.EqualTo(4231.1));
             Assert.That(returned.IsSplitRequested, Is.EqualTo(partition.IsSplitRequested));
@@ -1506,8 +1506,8 @@ namespace EXBP.Dipren.Tests.Data
             public Task InsertSplitPartitionAsync(Partition partitionToUpdate, Partition partitionToInsert, CancellationToken cancellation)
                 => this._store.InsertSplitPartitionAsync(partitionToUpdate, partitionToInsert, cancellation);
 
-            public Task<Partition> ReportProgressAsync(Guid id, string owner, DateTime timestamp, string position, long progress, bool completed, double throughput, CancellationToken cancellation)
-                => this._store.ReportProgressAsync(id, owner, timestamp, position, progress, completed, throughput, cancellation);
+            public Task<Partition> ReportProgressAsync(Guid id, string owner, DateTime timestamp, string position, long processed, long remaining, bool completed, double throughput, CancellationToken cancellation)
+                => this._store.ReportProgressAsync(id, owner, timestamp, position, processed, remaining, completed, throughput, cancellation);
 
             public Task<Job> RetrieveJobAsync(string id, CancellationToken cancellation)
                 => this._store.RetrieveJobAsync(id, cancellation);

--- a/source/EXBP.Dipren/Data/IEngineDataStore.cs
+++ b/source/EXBP.Dipren/Data/IEngineDataStore.cs
@@ -299,8 +299,11 @@ namespace EXBP.Dipren.Data
         /// <param name="position">
         ///   The key of the last item processed in the key range of the partition.
         /// </param>
-        /// <param name="progress">
-        ///   The number of items processed since the last progress update.
+        /// <param name="processed">
+        ///   The total number of items processed in this partition.
+        /// </param>
+        /// <param name="remaining">
+        ///   The total number of items remaining in this partition.
         /// </param>
         /// <param name="completed">
         ///   <see langword="true"/> if the partition is completed; otherwise, <see langword="false"/>.
@@ -322,7 +325,7 @@ namespace EXBP.Dipren.Data
         /// <exception cref="UnknownIdentifierException">
         ///   A partition with the specified unique identifier does not exist.
         /// </exception>
-        Task<Partition> ReportProgressAsync(Guid id, string owner, DateTime timestamp, string position, long progress, bool completed, double throughput, CancellationToken cancellation);
+        Task<Partition> ReportProgressAsync(Guid id, string owner, DateTime timestamp, string position, long processed, long remaining, bool completed, double throughput, CancellationToken cancellation);
 
         /// <summary>
         ///   Gets a status report for the job with the specified identifier.

--- a/source/EXBP.Dipren/Data/Memory/MemoryEngineDataStore.cs
+++ b/source/EXBP.Dipren/Data/Memory/MemoryEngineDataStore.cs
@@ -676,8 +676,11 @@ namespace EXBP.Dipren.Data.Memory
         /// <param name="position">
         ///   The key of the last item processed in the key range of the partition.
         /// </param>
-        /// <param name="progress">
-        ///   The number of items processed since the last progress update.
+        /// <param name="processed">
+        ///   The total number of items processed in this partition.
+        /// </param>
+        /// <param name="remaining">
+        ///   The total number of items remaining in this partition.
         /// </param>
         /// <param name="completed">
         ///   <see langword="true"/> if the partition is completed; otherwise, <see langword="false"/>.
@@ -699,7 +702,7 @@ namespace EXBP.Dipren.Data.Memory
         /// <exception cref="UnknownIdentifierException">
         ///   A partition with the specified unique identifier does not exist.
         /// </exception>
-        public Task<Partition> ReportProgressAsync(Guid id, string owner, DateTime timestamp, string position, long progress, bool completed, double throughput, CancellationToken cancellation)
+        public Task<Partition> ReportProgressAsync(Guid id, string owner, DateTime timestamp, string position, long processed, long remaining, bool completed, double throughput, CancellationToken cancellation)
         {
             Assert.ArgumentIsNotNull(owner, nameof(owner));
             Assert.ArgumentIsNotNull(position, nameof(position));
@@ -724,8 +727,8 @@ namespace EXBP.Dipren.Data.Memory
                 {
                     Updated = timestamp,
                     Position = position,
-                    Processed = (persisted.Processed + progress),
-                    Remaining = (persisted.Remaining - progress),
+                    Processed = processed,
+                    Remaining = remaining,
                     IsCompleted = completed,
                     Throughput = throughput
                 };

--- a/source/EXBP.Dipren/Data/ResilientEngineDataStore.cs
+++ b/source/EXBP.Dipren/Data/ResilientEngineDataStore.cs
@@ -146,8 +146,11 @@ namespace EXBP.Dipren.Data
         /// <param name="position">
         ///   The key of the last item processed in the key range of the partition.
         /// </param>
-        /// <param name="progress">
-        ///   The number of items processed since the last progress update.
+        /// <param name="processed">
+        ///   The total number of items processed in this partition.
+        /// </param>
+        /// <param name="remaining">
+        ///   The total number of items remaining in this partition.
         /// </param>
         /// <param name="completed">
         ///   <see langword="true"/> if the partition is completed; otherwise, <see langword="false"/>.
@@ -169,8 +172,8 @@ namespace EXBP.Dipren.Data
         /// <exception cref="UnknownIdentifierException">
         ///   A partition with the specified unique identifier does not exist.
         /// </exception>
-        public Task<Partition> ReportProgressAsync(Guid id, string owner, DateTime timestamp, string position, long progress, bool completed, double throughput, CancellationToken cancellation)
-            => this.Strategy.ExecuteAsync(async () => await this.Store.ReportProgressAsync(id, owner, timestamp, position, progress, completed, throughput, cancellation), cancellation);
+        public Task<Partition> ReportProgressAsync(Guid id, string owner, DateTime timestamp, string position, long processed, long remaining, bool completed, double throughput, CancellationToken cancellation)
+            => this.Strategy.ExecuteAsync(async () => await this.Store.ReportProgressAsync(id, owner, timestamp, position, processed, remaining, completed, throughput, cancellation), cancellation);
 
         /// <summary>
         ///   Retrieves the job with the specified identifier from the data store.

--- a/source/Store/Postgres/EXBP.Dipren.Data.Postgres/PostgresEngineDataStoreImplementation.cs
+++ b/source/Store/Postgres/EXBP.Dipren.Data.Postgres/PostgresEngineDataStoreImplementation.cs
@@ -382,8 +382,11 @@ namespace EXBP.Dipren.Data.Postgres
         /// <param name="position">
         ///   The key of the last item processed in the key range of the partition.
         /// </param>
-        /// <param name="progress">
-        ///   The number of items processed since the last progress update.
+        /// <param name="processed">
+        ///   The total number of items processed in this partition.
+        /// </param>
+        /// <param name="remaining">
+        ///   The total number of items remaining in this partition.
         /// </param>
         /// <param name="completed">
         ///   <see langword="true"/> if the partition is completed; otherwise, <see langword="false"/>.
@@ -405,7 +408,7 @@ namespace EXBP.Dipren.Data.Postgres
         /// <exception cref="UnknownIdentifierException">
         ///   A partition with the specified unique identifier does not exist.
         /// </exception>
-        public async Task<Partition> ReportProgressAsync(Guid id, string owner, DateTime timestamp, string position, long progress, bool completed, double throughput, CancellationToken cancellation)
+        public async Task<Partition> ReportProgressAsync(Guid id, string owner, DateTime timestamp, string position, long processed, long remaining, bool completed, double throughput, CancellationToken cancellation)
         {
             Assert.ArgumentIsNotNull(owner, nameof(owner));
             Assert.ArgumentIsNotNull(position, nameof(position));
@@ -429,7 +432,8 @@ namespace EXBP.Dipren.Data.Postgres
 
                 command.Parameters.AddWithValue("@updated", NpgsqlDbType.Timestamp, uktsTimestamp);
                 command.Parameters.AddWithValue("@position", NpgsqlDbType.Text, ((object) position) ?? DBNull.Value);
-                command.Parameters.AddWithValue("@progress", NpgsqlDbType.Bigint, progress);
+                command.Parameters.AddWithValue("@processed", NpgsqlDbType.Bigint, processed);
+                command.Parameters.AddWithValue("@remaining", NpgsqlDbType.Bigint, remaining);
                 command.Parameters.AddWithValue("@completed", NpgsqlDbType.Boolean, completed);
                 command.Parameters.AddWithValue("@id", NpgsqlDbType.Char, COLUMN_PARTITION_ID_LENGTH, sid);
                 command.Parameters.AddWithValue("@owner", NpgsqlDbType.Varchar, COLUMN_PARTITION_OWNER_LENGTH, owner);

--- a/source/Store/Postgres/EXBP.Dipren.Data.Postgres/PostgresEngineDataStoreImplementationResources.Designer.cs
+++ b/source/Store/Postgres/EXBP.Dipren.Data.Postgres/PostgresEngineDataStoreImplementationResources.Designer.cs
@@ -300,8 +300,8 @@ namespace EXBP.Dipren.Data.Postgres {
         ///SET
         ///  &quot;updated&quot; = @updated,
         ///  &quot;position&quot; = @position,
-        ///  &quot;processed&quot; = (&quot;processed&quot; + @progress),
-        ///  &quot;remaining&quot; = (&quot;remaining&quot; - @progress),
+        ///  &quot;processed&quot; = @processed,
+        ///  &quot;remaining&quot; = @remaining,
         ///  &quot;throughput&quot; = @throughput,
         ///  &quot;is_completed&quot; = @completed
         ///WHERE
@@ -316,7 +316,8 @@ namespace EXBP.Dipren.Data.Postgres {
         ///  &quot;first&quot; AS &quot;first&quot;,
         ///  &quot;last&quot; AS &quot;last&quot;,
         ///  &quot;is_inclusive&quot; AS &quot;is_inclusive&quot;,
-        ///  &quot;position&quot; [rest of string was truncated]&quot;;.
+        ///  &quot;position&quot; AS &quot;position&quot;,
+        ///  &quot;processed&quot; [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string QueryReportProgress {
             get {

--- a/source/Store/Postgres/EXBP.Dipren.Data.Postgres/PostgresEngineDataStoreImplementationResources.resx
+++ b/source/Store/Postgres/EXBP.Dipren.Data.Postgres/PostgresEngineDataStoreImplementationResources.resx
@@ -297,8 +297,8 @@ RETURNING
 SET
   "updated" = @updated,
   "position" = @position,
-  "processed" = ("processed" + @progress),
-  "remaining" = ("remaining" - @progress),
+  "processed" = @processed,
+  "remaining" = @remaining,
   "throughput" = @throughput,
   "is_completed" = @completed
 WHERE
@@ -357,7 +357,7 @@ WHERE
   COALESCE(MAX(t2."updated"), t1."updated") AS "last_activity",
   COALESCE((SELECT SUM("acquired") - COUNT(1) FROM "dipren"."partitions" WHERE ("job_id" = t1."id") AND ("acquired" &gt; 0)), 0) AS "ownership_changes",
   COUNT(1) FILTER (WHERE (t1."state" = 'processing') AND (t2."is_completed" = FALSE) AND (t2."is_split_requested" = TRUE)) AS "split_requests_pending",
-  COALESCE(SUM("throughput") FILTER (WHERE (t1."state" = 'processing') AND (t2."is_completed" = FALSE) AND (t2."updated" >= (@timestamp - ('1 MICROSECOND'::INTERVAL * ((t1."timeout" + t1."clock_drift")::DOUBLE PRECISION / 10))))), 0.0) AS "current_throughput"
+  COALESCE(SUM("throughput") FILTER (WHERE (t1."state" = 'processing') AND (t2."is_completed" = FALSE) AND (t2."updated" &gt;= (@timestamp - ('1 MICROSECOND'::INTERVAL * ((t1."timeout" + t1."clock_drift")::DOUBLE PRECISION / 10))))), 0.0) AS "current_throughput"
 FROM
   "dipren"."jobs" t1
   LEFT JOIN "dipren"."partitions" t2 ON (t1."id" = t2."job_id")

--- a/source/Store/SQLite/EXBP.Dipren.Data.SQLite/SQLiteEngineDataStore.cs
+++ b/source/Store/SQLite/EXBP.Dipren.Data.SQLite/SQLiteEngineDataStore.cs
@@ -1004,8 +1004,11 @@ namespace EXBP.Dipren.Data.SQLite
         /// <param name="position">
         ///   The key of the last item processed in the key range of the partition.
         /// </param>
-        /// <param name="progress">
-        ///   The number of items processed since the last progress update.
+        /// <param name="processed">
+        ///   The total number of items processed in this partition.
+        /// </param>
+        /// <param name="remaining">
+        ///   The total number of items remaining in this partition.
         /// </param>
         /// <param name="completed">
         ///   <see langword="true"/> if the partition is completed; otherwise, <see langword="false"/>.
@@ -1027,7 +1030,7 @@ namespace EXBP.Dipren.Data.SQLite
         /// <exception cref="UnknownIdentifierException">
         ///   A partition with the specified unique identifier does not exist.
         /// </exception>
-        public async Task<Partition> ReportProgressAsync(Guid id, string owner, DateTime timestamp, string position, long progress, bool completed, double throughput, CancellationToken cancellation)
+        public async Task<Partition> ReportProgressAsync(Guid id, string owner, DateTime timestamp, string position, long processed, long remaining, bool completed, double throughput, CancellationToken cancellation)
         {
             Assert.ArgumentIsNotNull(owner, nameof(owner));
             Assert.ArgumentIsNotNull(position, nameof(position));
@@ -1051,7 +1054,8 @@ namespace EXBP.Dipren.Data.SQLite
 
                 command.Parameters.AddWithValue("$updated", timestamp);
                 command.Parameters.AddWithValue("$position", position);
-                command.Parameters.AddWithValue("$progress", progress);
+                command.Parameters.AddWithValue("$processed", processed);
+                command.Parameters.AddWithValue("$remaining", remaining);
                 command.Parameters.AddWithValue("$completed", completed);
                 command.Parameters.AddWithValue("$throughput", throughput);
                 command.Parameters.AddWithValue("$id", sid);

--- a/source/Store/SQLite/EXBP.Dipren.Data.SQLite/SQLiteEngineDataStoreResources.Designer.cs
+++ b/source/Store/SQLite/EXBP.Dipren.Data.SQLite/SQLiteEngineDataStoreResources.Designer.cs
@@ -338,8 +338,8 @@ namespace EXBP.Dipren.Data.SQLite {
         ///SET
         ///  &quot;updated&quot; = $updated,
         ///  &quot;position&quot; = $position,
-        ///  &quot;processed&quot; = (&quot;processed&quot; + $progress),
-        ///  &quot;remaining&quot; = (&quot;remaining&quot; - $progress),
+        ///  &quot;processed&quot; = $processed,
+        ///  &quot;remaining&quot; = $remaining,
         ///  &quot;throughput&quot; = $throughput,
         ///  &quot;is_completed&quot; = $completed
         ///WHERE
@@ -354,7 +354,8 @@ namespace EXBP.Dipren.Data.SQLite {
         ///  &quot;first&quot; AS &quot;first&quot;,
         ///  &quot;last&quot; AS &quot;last&quot;,
         ///  &quot;is_inclusive&quot; AS &quot;is_inclusive&quot;,
-        ///  &quot;position&quot; AS &quot;posi [rest of string was truncated]&quot;;.
+        ///  &quot;position&quot; AS &quot;position&quot;,
+        ///  &quot;processed&quot; AS &quot;proc [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string QueryReportProgress {
             get {

--- a/source/Store/SQLite/EXBP.Dipren.Data.SQLite/SQLiteEngineDataStoreResources.resx
+++ b/source/Store/SQLite/EXBP.Dipren.Data.SQLite/SQLiteEngineDataStoreResources.resx
@@ -344,8 +344,8 @@ RETURNING
 SET
   "updated" = $updated,
   "position" = $position,
-  "processed" = ("processed" + $progress),
-  "remaining" = ("remaining" - $progress),
+  "processed" = $processed,
+  "remaining" = $remaining,
   "throughput" = $throughput,
   "is_completed" = $completed
 WHERE
@@ -404,7 +404,7 @@ WHERE
   COALESCE(MAX(t2."updated"), t1."updated") AS "last_activity",
   COALESCE((SELECT SUM(t2."acquired") - COUNT(1) FROM "partitions" WHERE ("job_id" = t1."id") AND ("acquired" &gt; 0)), 0) AS "ownership_changes",
   (SELECT COUNT(1) FROM "partitions" WHERE ("job_id" = t1."id") AND (t1."state" = 2) AND ("is_completed" = 0) AND ("is_split_requested" = 1)) AS "split_requests_pending",
-  COALESCE((SELECT SUM("throughput") FROM "partitions" WHERE ("job_id" = t1."id") AND (t1."state" = 2) AND ("is_completed" = 0) AND ("updated" >= DATETIME($timestamp, '-' || ((t1."timeout" * 1.0) / 10000000) || ' SECOND'))), 0.0) AS "current_throughput"
+  COALESCE((SELECT SUM("throughput") FROM "partitions" WHERE ("job_id" = t1."id") AND (t1."state" = 2) AND ("is_completed" = 0) AND ("updated" &gt;= DATETIME($timestamp, '-' || ((t1."timeout" * 1.0) / 10000000) || ' SECOND'))), 0.0) AS "current_throughput"
 FROM
   "jobs" t1
   LEFT JOIN "partitions" t2 ON (t1."id" = t2."job_id")


### PR DESCRIPTION
Changes the `Engine.ProcessPartitionAsync(...)` method to calculate the number of processed and remaining keys internally to relief data store implementations of this responsibility.