### PR TITLE
Moves code for generating events in the Scheduler and Engine types into separate classes

### DIFF
--- a/source/EXBP.Dipren/Engine.cs
+++ b/source/EXBP.Dipren/Engine.cs
@@ -688,7 +688,7 @@ namespace EXBP.Dipren
 
 
         /// <summary>
-        ///   Exposes methods for raising <see cref="Engine"/> events.
+        ///   Implements methods for raising <see cref="Engine"/> events.
         /// </summary>
         private sealed class Events
         {
@@ -707,6 +707,7 @@ namespace EXBP.Dipren
 
                 this._dispatcher = dispatcher;
             }
+
 
             /// <summary>
             ///   Raises the event when a distributed processing job is started.

--- a/source/EXBP.Dipren/Scheduler.cs
+++ b/source/EXBP.Dipren/Scheduler.cs
@@ -141,11 +141,11 @@ namespace EXBP.Dipren
             DateTime timestamp = this.Clock.GetCurrentTimestamp();
             Job result = new Job(job.Id, timestamp, timestamp, JobState.Initializing, settings.BatchSize, settings.Timeout, settings.ClockDrift);
 
-            await this._events.CreatingJobAsync(job.Id, cancellation);
+            await this._events.RaiseCreatingJobAsync(job.Id, cancellation);
 
             await this.Store.InsertJobAsync(result, cancellation);
 
-            await this._events.JobCreatedAsync(job.Id, cancellation);
+            await this._events.RaiseJobCreatedAsync(job.Id, cancellation);
 
             return result;
         }
@@ -180,8 +180,8 @@ namespace EXBP.Dipren
 
             Guid partitionId = Guid.NewGuid();
 
-            await this._events.CreatingInitialPartitionAsync(job.Id, partitionId, cancellation);
-            await this._events.RetrievingRangeBoundariesAsync(job.Id, partitionId, cancellation);
+            await this._events.RaiseCreatingInitialPartitionAsync(job.Id, partitionId, cancellation);
+            await this._events.RaiseRetrievingRangeBoundariesAsync(job.Id, partitionId, cancellation);
 
             Stopwatch stopwatch = Stopwatch.StartNew();
 
@@ -189,9 +189,9 @@ namespace EXBP.Dipren
 
             stopwatch.Stop();
 
-            await this._events.RangeBoundariesRetrievedAsync(job.Id, partitionId, job.Serializer, range.First, range.Last, stopwatch.Elapsed, cancellation);
+            await this._events.RaiseRangeBoundariesRetrievedAsync(job.Id, partitionId, job.Serializer, range.First, range.Last, stopwatch.Elapsed, cancellation);
 
-            await this._events.EstimatingRangeSizeAsync(job.Id, partitionId, cancellation);
+            await this._events.RaiseEstimatingRangeSizeAsync(job.Id, partitionId, cancellation);
 
             stopwatch.Restart();
 
@@ -199,7 +199,7 @@ namespace EXBP.Dipren
 
             stopwatch.Stop();
 
-            await this._events.RangeSizeEstimatedAsync(job.Id, partitionId, remaining, stopwatch.Elapsed, cancellation);
+            await this._events.RaiseRangeSizeEstimatedAsync(job.Id, partitionId, remaining, stopwatch.Elapsed, cancellation);
 
             //
             // When a split request is honored, the size of two key ranges is estimated. The timeout value should allow
@@ -208,7 +208,7 @@ namespace EXBP.Dipren
 
             if (stopwatch.Elapsed >= (settings.Timeout / 2))
             {
-                await this._events.TimeoutValueTooLowAsync(job.Id, partitionId, cancellation);
+                await this._events.RaiseTimeoutValueTooLowAsync(job.Id, partitionId, cancellation);
             }
 
             DateTime timestampPartitionCreated = this.Clock.GetCurrentTimestamp();
@@ -217,7 +217,7 @@ namespace EXBP.Dipren
 
             await this.Store.InsertPartitionAsync(result, cancellation);
 
-            await this._events.InitialPartitionCreatedAsync(job.Id, partitionId, cancellation);
+            await this._events.RaiseInitialPartitionCreatedAsync(job.Id, partitionId, cancellation);
 
             return result;
         }
@@ -270,11 +270,20 @@ namespace EXBP.Dipren
         }
 
 
+        /// <summary>
+        ///   Implements methods for raising <see cref="Scheduler"/> events.
+        /// </summary>
         private sealed class Events
         {
             private readonly EventDispatcher _dispatcher;
 
 
+            /// <summary>
+            ///   Initializes a new instance of the <see cref="Events"/> class.
+            /// </summary>
+            /// <param name="dispatcher">
+            ///   The <see cref="Node.EventDispatcher"/> to use to dispatch events.
+            /// </param>
             internal Events(EventDispatcher dispatcher)
             {
                 Debug.Assert(dispatcher != null);
@@ -283,35 +292,125 @@ namespace EXBP.Dipren
             }
 
 
-            internal async Task CreatingJobAsync(string jobId, CancellationToken cancellation)
+            /// <summary>
+            ///   Raises the event when a distributed processing job is being created.
+            /// </summary>
+            /// <param name="jobId">
+            ///   The unique identifier of the distributed processing job.
+            /// </param>
+            /// <param name="cancellation">
+            ///   The <see cref="CancellationToken"/> used to propagate notifications that the operation should be
+            ///   canceled.
+            /// </param>
+            /// <returns>
+            ///   A <see cref="Task"/> object that represents the asynchronous operation.
+            /// </returns>
+            internal async Task RaiseCreatingJobAsync(string jobId, CancellationToken cancellation)
             {
                 Debug.Assert(jobId != null);
 
                 await this._dispatcher.DispatchEventAsync(EventSeverity.Information, jobId, SchedulerResources.EventCreatingJob, cancellation);
             }
 
-            internal async Task JobCreatedAsync(string jobId, CancellationToken cancellation)
+            /// <summary>
+            ///   Raises the event when a distributed processing job has been created.
+            /// </summary>
+            /// <param name="jobId">
+            ///   The unique identifier of the distributed processing job.
+            /// </param>
+            /// <param name="cancellation">
+            ///   The <see cref="CancellationToken"/> used to propagate notifications that the operation should be
+            ///   canceled.
+            /// </param>
+            /// <returns>
+            ///   A <see cref="Task"/> object that represents the asynchronous operation.
+            /// </returns>
+            internal async Task RaiseJobCreatedAsync(string jobId, CancellationToken cancellation)
             {
                 Debug.Assert(jobId != null);
 
                 await this._dispatcher.DispatchEventAsync(EventSeverity.Information, jobId, SchedulerResources.EventJobCreated, cancellation);
             }
 
-            internal async Task CreatingInitialPartitionAsync(string jobId, Guid partitionId, CancellationToken cancellation)
+            /// <summary>
+            ///   Raises the event when the initial partition for the distributed processing job is being created.
+            /// </summary>
+            /// <param name="jobId">
+            ///   The unique identifier of the distributed processing job.
+            /// </param>
+            /// <param name="partitionId">
+            ///   The unique identifier of the partition.
+            /// </param>
+            /// <param name="cancellation">
+            ///   The <see cref="CancellationToken"/> used to propagate notifications that the operation should be
+            ///   canceled.
+            /// </param>
+            /// <returns>
+            ///   A <see cref="Task"/> object that represents the asynchronous operation.
+            /// </returns>
+            internal async Task RaiseCreatingInitialPartitionAsync(string jobId, Guid partitionId, CancellationToken cancellation)
             {
                 Debug.Assert(jobId != null);
 
                 await this._dispatcher.DispatchEventAsync(EventSeverity.Information, jobId, partitionId, SchedulerResources.EventCreatingInitialPartition, cancellation);
             }
 
-            internal async Task RetrievingRangeBoundariesAsync(string jobId, Guid partitionId, CancellationToken cancellation)
+            /// <summary>
+            ///   Raises the event when the boundaries for the partition are being retrieved.
+            /// </summary>
+            /// <param name="jobId">
+            ///   The unique identifier of the distributed processing job.
+            /// </param>
+            /// <param name="partitionId">
+            ///   The unique identifier of the partition.
+            /// </param>
+            /// <param name="cancellation">
+            ///   The <see cref="CancellationToken"/> used to propagate notifications that the operation should be
+            ///   canceled.
+            /// </param>
+            /// <returns>
+            ///   A <see cref="Task"/> object that represents the asynchronous operation.
+            /// </returns>
+            internal async Task RaiseRetrievingRangeBoundariesAsync(string jobId, Guid partitionId, CancellationToken cancellation)
             {
                 Debug.Assert(jobId != null);
 
                 await this._dispatcher.DispatchEventAsync(EventSeverity.Information, jobId, partitionId, SchedulerResources.EventRetrievingRangeBoundaries, cancellation);
             }
 
-            internal async Task RangeBoundariesRetrievedAsync<TKey>(string jobId, Guid partitionId, IKeySerializer<TKey> serializer, TKey first, TKey last, TimeSpan duration, CancellationToken cancellation)
+            /// <summary>
+            ///   Raises the event when the boundaries for the partition have been retrieved.
+            /// </summary>
+            /// <typeparam name="TKey">
+            ///   The type of the item key.
+            /// </typeparam>
+            /// <param name="jobId">
+            ///   The unique identifier of the distributed processing job.
+            /// </param>
+            /// <param name="partitionId">
+            ///   The unique identifier of the partition.
+            /// </param>
+            /// <param name="serializer">
+            ///   The <see cref="IKeySerializer{TKey}"/> of type <typeparamref name="TKey"/> that is used to serialize
+            ///   keys.
+            /// </param>
+            /// <param name="first">
+            ///   The first key in the range.
+            /// </param>
+            /// <param name="last">
+            ///   The last key in the range.
+            /// </param>
+            /// <param name="duration">
+            ///   The time it took to retrieve the range boundaries.
+            /// </param>
+            /// <param name="cancellation">
+            ///   The <see cref="CancellationToken"/> used to propagate notifications that the operation should be
+            ///   canceled.
+            /// </param>
+            /// <returns>
+            ///   A <see cref="Task"/> object that represents the asynchronous operation.
+            /// </returns>
+            internal async Task RaiseRangeBoundariesRetrievedAsync<TKey>(string jobId, Guid partitionId, IKeySerializer<TKey> serializer, TKey first, TKey last, TimeSpan duration, CancellationToken cancellation)
             {
                 Debug.Assert(jobId != null);
                 Debug.Assert(serializer != null);
@@ -327,14 +426,52 @@ namespace EXBP.Dipren
                 await this._dispatcher.DispatchEventAsync(EventSeverity.Information, jobId, partitionId, message, cancellation);
             }
 
-            internal async Task EstimatingRangeSizeAsync(string jobId, Guid partitionId, CancellationToken cancellation)
+            /// <summary>
+            ///   Raises the event when the size of a key range is being estimated.
+            /// </summary>
+            /// <param name="jobId">
+            ///   The unique identifier of the distributed processing job.
+            /// </param>
+            /// <param name="partitionId">
+            ///   The unique identifier of the partition.
+            /// </param>
+            /// <param name="cancellation">
+            ///   The <see cref="CancellationToken"/> used to propagate notifications that the operation should be
+            ///   canceled.
+            /// </param>
+            /// <returns>
+            ///   A <see cref="Task"/> object that represents the asynchronous operation.
+            /// </returns>
+            internal async Task RaiseEstimatingRangeSizeAsync(string jobId, Guid partitionId, CancellationToken cancellation)
             {
                 Debug.Assert(jobId != null);
 
                 await this._dispatcher.DispatchEventAsync(EventSeverity.Information, jobId, partitionId, SchedulerResources.EventEstimatingRangeSize, cancellation);
             }
 
-            internal async Task RangeSizeEstimatedAsync(string jobId, Guid partitionId, long count, TimeSpan duration, CancellationToken cancellation)
+            /// <summary>
+            ///   Raises the event when the size of a key range has been estimated.
+            /// </summary>
+            /// <param name="jobId">
+            ///   The unique identifier of the distributed processing job.
+            /// </param>
+            /// <param name="partitionId">
+            ///   The unique identifier of the partition.
+            /// </param>
+            /// <param name="count">
+            ///   The number of keys in the range.
+            /// </param>
+            /// <param name="duration">
+            ///   The time it took to complete the operation.
+            /// </param>
+            /// <param name="cancellation">
+            ///   The <see cref="CancellationToken"/> used to propagate notifications that the operation should be
+            ///   canceled.
+            /// </param>
+            /// <returns>
+            ///   A <see cref="Task"/> object that represents the asynchronous operation.
+            /// </returns>
+            internal async Task RaiseRangeSizeEstimatedAsync(string jobId, Guid partitionId, long count, TimeSpan duration, CancellationToken cancellation)
             {
                 Debug.Assert(jobId != null);
                 Debug.Assert(count >= 0);
@@ -345,14 +482,46 @@ namespace EXBP.Dipren
                 await this._dispatcher.DispatchEventAsync(EventSeverity.Information, jobId, partitionId, message, cancellation);
             }
 
-            internal async Task TimeoutValueTooLowAsync(string jobId, Guid partitionId, CancellationToken cancellation)
+            /// <summary>
+            ///   Raises the event when the duration of creating a partition exceeded that configured timeout value.
+            /// </summary>
+            /// <param name="jobId">
+            ///   The unique identifier of the distributed processing job.
+            /// </param>
+            /// <param name="partitionId">
+            ///   The unique identifier of the partition.
+            /// </param>
+            /// <param name="cancellation">
+            ///   The <see cref="CancellationToken"/> used to propagate notifications that the operation should be
+            ///   canceled.
+            /// </param>
+            /// <returns>
+            ///   A <see cref="Task"/> object that represents the asynchronous operation.
+            /// </returns>
+            internal async Task RaiseTimeoutValueTooLowAsync(string jobId, Guid partitionId, CancellationToken cancellation)
             {
                 Debug.Assert(jobId != null);
 
                 await this._dispatcher.DispatchEventAsync(EventSeverity.Warning, jobId, partitionId, SchedulerResources.EventTimeoutValueTooLow, cancellation);
             }
 
-            internal async Task InitialPartitionCreatedAsync(string jobId, Guid partitionId, CancellationToken cancellation)
+            /// <summary>
+            ///   Raises the event when the initial partition for a distributed processing job has been created.
+            /// </summary>
+            /// <param name="jobId">
+            ///   The unique identifier of the distributed processing job.
+            /// </param>
+            /// <param name="partitionId">
+            ///   The unique identifier of the partition.
+            /// </param>
+            /// <param name="cancellation">
+            ///   The <see cref="CancellationToken"/> used to propagate notifications that the operation should be
+            ///   canceled.
+            /// </param>
+            /// <returns>
+            ///   A <see cref="Task"/> object that represents the asynchronous operation.
+            /// </returns>
+            internal async Task RaiseInitialPartitionCreatedAsync(string jobId, Guid partitionId, CancellationToken cancellation)
             {
                 Debug.Assert(jobId != null);
 


### PR DESCRIPTION
This change significantly reduces clutter in the code that implements scheduling and processing.